### PR TITLE
Change PersistMode to kPersistParameters for drivetrain motors

### DIFF
--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -40,13 +40,13 @@ public class Drivetrain extends SubsystemBase implements AutoCloseable {
     invertedConfig.inverted(true);
 
     frontLeftMotor.configure(
-        defaultConfig, ResetMode.kResetSafeParameters, PersistMode.kNoPersistParameters);
+        defaultConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
     frontRightMotor.configure(
-        invertedConfig, ResetMode.kResetSafeParameters, PersistMode.kNoPersistParameters);
+        invertedConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
     backLeftMotor.configure(
-        defaultConfig, ResetMode.kResetSafeParameters, PersistMode.kNoPersistParameters);
+        defaultConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
     backRightMotor.configure(
-        invertedConfig, ResetMode.kResetSafeParameters, PersistMode.kNoPersistParameters);
+        invertedConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
   }
 
   /**


### PR DESCRIPTION
Updated drivetrain motor configurations to use PersistMode.kPersistParameters
so settings persist across reboots.